### PR TITLE
Revert "fix: add -fPIC cflags. 避免链接libdpkg编译报错"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dpkg (1.22.6deepin6) unstable; urgency=medium
+
+  * Revert 'fix: add -fPIC cflags.'
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Mon, 28 Jul 2025 16:48:01 +0800
+
 dpkg (1.22.6deepin5) unstable; urgency=medium
 
   * feat: add sw64 support.

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,6 @@ WFLAGS := \
 	-Wno-missing-field-initializers \
 	-Wno-nonnull-compare \
 	-Wno-unused-parameter \
-	-fPIC \
 	# EOL
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all


### PR DESCRIPTION
This reverts commit a6116f2572ffdaccbebc25892830813916bdac3c.

The -fPIC flag is unnecessary for dpkg since it doesn't build any shared
libraries (.so files).
