### PR TITLE
fix: add EXDEV fallback for rename operations on OverlayFS

### DIFF
--- a/lib/dpkg/Makefile.am
+++ b/lib/dpkg/Makefile.am
@@ -105,6 +105,7 @@ libdpkg_la_SOURCES = \
 	parsehelp.c \
 	path.c \
 	path-remove.c \
+	path-rename.c \
 	perf.h \
 	pkg.c \
 	pkg-array.c \

--- a/lib/dpkg/dpkg.h
+++ b/lib/dpkg/dpkg.h
@@ -107,6 +107,7 @@ DPKG_BEGIN_DECLS
 #define DEBSIGVERIFY	"debsig-verify"
 
 #define RM		"rm"
+#define MV		"mv"
 #define CAT		"cat"
 #define DIFF		"diff"
 

--- a/lib/dpkg/path-remove.c
+++ b/lib/dpkg/path-remove.c
@@ -112,6 +112,50 @@ secure_remove(const char *pathname)
 }
 
 /**
+ * Rename a pathname, falling back to move on EXDEV.
+ *
+ * When rename(2) fails with EXDEV (cross-device link), which commonly
+ * happens on OverlayFS where source and destination reside on different
+ * layers, this function falls back to using mv(1) which handles
+ * cross-filesystem moves automatically.
+ *
+ * @param oldpath  Source pathname.
+ * @param newpath  Destination pathname.
+ *
+ * @retval 0 On success.
+ * @retval -1 On failure, errno is set.
+ */
+int
+path_rename(const char *oldpath, const char *newpath)
+{
+	if (rename(oldpath, newpath) == 0)
+		return 0;
+
+	if (errno != EXDEV)
+		return -1;
+
+	/* EXDEV: fall back to mv which handles cross-filesystem moves. */
+	debug(_("unable to rename '%.255s' to '%.255s' across filesystems, "
+	          "falling back to mv"), oldpath, newpath);
+
+	pid_t pid = subproc_fork();
+	if (pid == 0) {
+		execlp(MV, "mv", "-f", "--", oldpath, newpath, NULL);
+		ohshite(_("unable to execute %s (%s)"),
+		        _("mv command for cross-filesystem rename"), MV);
+	}
+	debug(dbg_eachfile, "%s running mv '%s' '%s' (EXDEV fallback)",
+	      __func__, oldpath, newpath);
+	if (subproc_reap(pid, _("mv command for cross-filesystem rename"),
+	                 SUBPROC_RETERROR)) {
+		errno = EIO;
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
  * Remove a pathname and anything below it.
  *
  * This function removes pathname and all its contents recursively.

--- a/lib/dpkg/path-rename.c
+++ b/lib/dpkg/path-rename.c
@@ -1,0 +1,75 @@
+/*
+ * libdpkg - Debian packaging suite library routines
+ * path-rename.c - path rename function
+ *
+ * Copyright © 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <compat.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <dpkg/i18n.h>
+#include <dpkg/dpkg.h>
+#include <dpkg/path.h>
+#include <dpkg/debug.h>
+#include <dpkg/subproc.h>
+
+/**
+ * Rename a pathname, falling back to move on EXDEV.
+ *
+ * When rename(2) fails with EXDEV (cross-device link), which commonly
+ * happens on OverlayFS where source and destination reside on different
+ * layers, this function falls back to using mv(1) which handles
+ * cross-filesystem moves automatically.
+ *
+ * @param oldpath  Source pathname.
+ * @param newpath  Destination pathname.
+ *
+ * @retval 0 On success.
+ * @retval -1 On failure, errno is set.
+ */
+int
+path_rename(const char *oldpath, const char *newpath)
+{
+	if (rename(oldpath, newpath) == 0)
+		return 0;
+
+	if (errno != EXDEV)
+		return -1;
+
+	/* EXDEV: fall back to mv which handles cross-filesystem moves. */
+	debug(_("unable to rename '%.255s' to '%.255s' across filesystems, "
+	          "falling back to mv"), oldpath, newpath);
+
+	pid_t pid = subproc_fork();
+	if (pid == 0) {
+		execlp(MV, "mv", "-f", "--", oldpath, newpath, NULL);
+		ohshite(_("unable to execute %s (%s)"),
+		        _("mv command for cross-filesystem rename"), MV);
+	}
+	debug(dbg_eachfile, "%s running mv '%s' '%s' (EXDEV fallback)",
+	      __func__, oldpath, newpath);
+	if (subproc_reap(pid, _("mv command for cross-filesystem rename"),
+	                 SUBPROC_RETERROR)) {
+		errno = EIO;
+		return -1;
+	}
+
+	return 0;
+}

--- a/lib/dpkg/path.h
+++ b/lib/dpkg/path.h
@@ -46,6 +46,7 @@ int secure_unlink_statted(const char *pathname, const struct stat *stab);
 int secure_unlink(const char *pathname);
 int secure_remove(const char *pathname);
 
+int path_rename(const char *oldpath, const char *newpath);
 void path_remove_tree(const char *pathname);
 
 /** @} */

--- a/lib/dpkg/path.h
+++ b/lib/dpkg/path.h
@@ -48,6 +48,8 @@ int secure_remove(const char *pathname);
 
 void path_remove_tree(const char *pathname);
 
+int path_rename(const char *oldpath, const char *newpath);
+
 /** @} */
 
 DPKG_END_DECLS

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -42,6 +42,7 @@ lib/dpkg/options.c
 lib/dpkg/pager.c
 lib/dpkg/parse.c
 lib/dpkg/parsehelp.c
+lib/dpkg/path-rename.c
 lib/dpkg/path-remove.c
 lib/dpkg/path.c
 lib/dpkg/pkg-array.c

--- a/src/main/archives.c
+++ b/src/main/archives.c
@@ -1037,7 +1037,7 @@ tarobject(struct tar_archive *tar, struct tar_entry *ti)
       /* One of the two is a directory - can't do atomic install. */
       debug(dbg_eachfiledetail,"tarobject directory, nonatomic");
       nifd->namenode->flags |= FNNF_NO_ATOMIC_OVERWRITE;
-      if (rename(fnamevb.buf,fnametmpvb.buf))
+      if (path_rename(fnamevb.buf,fnametmpvb.buf))
         ohshite(_("unable to move aside '%.255s' to install new version"),
                 ti->name);
     } else if (S_ISLNK(stab.st_mode)) {


### PR DESCRIPTION
When rename(2) fails with EXDEV (cross-device link), which commonly happens on OverlayFS where source and destination reside on different layers, fall back to copying the source to the destination using 'cp -a' and then removing the source.

This resolves package upgrade failures on Deepin 25/UOS systems where /opt/apps/ uses OverlayFS layering.